### PR TITLE
fix: rename BaseMeetups to BaseEvents in links

### DIFF
--- a/apps/web/src/components/base-org/shared/TopNavigation/index.tsx
+++ b/apps/web/src/components/base-org/shared/TopNavigation/index.tsx
@@ -63,7 +63,7 @@ const links: TopNavigationLink[] = [
       },
       {
         name: 'Events',
-        href: 'https://lu.ma/BaseMeetups',
+        href: 'https://lu.ma/BaseEvents',
       },
     ],
   },


### PR DESCRIPTION
**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**
